### PR TITLE
Updating storm name/label sorting by stormid

### DIFF
--- a/src/hurrevac_storms.py
+++ b/src/hurrevac_storms.py
@@ -125,16 +125,21 @@ class StormsInfo:
         
 ##        logging.debug("Running GetStormNames")
         '''Get basins code from label in settings.json'''
-        '''It would be nice to sort storms by alphabet then greek alphabet 
-           when there are more than 26 storms'''
         StormBasins = hurrevacSettings['BasinsDictionary']
         basinCode = get_key(basinLabel, StormBasins)
-        #working with json
+        #Note: working with json
         stormNameStatusIDList = []
-        activeStorms = []
-        historicStorms = []
-        exerciseStorms = []
-        simulatedStorms = []
+        
+        activeStormsDictList = []
+        historicStormsDictList = []
+        exerciseStormsDictList = []
+        simulatedStormsDictList = []
+        
+        activeStormsLabelsList = []
+        historicStormsLabelsList = []
+        exerciseStormsLabelsList = []
+        simulatedStormsLabelsList = []
+        
         '''Iterate over storms for a given year, append to each list'''
         try:
             year = str(year)
@@ -145,32 +150,64 @@ class StormsInfo:
             stormId = str(storm['stormId'])
             stormStatus = str(storm['status'])
             stormBasin = str(storm['basin'])
-            stormLabel = stormName + " (" + stormStatus + ") " + " [" + stormId + "]"
+            stormDict = {"Name":stormName,"Status":stormStatus,"StormId":stormId}
             if stormBasin == basinCode:
                 if stormStatus == "Simulated":
-                    simulatedStorms.append(stormLabel)
+                    simulatedStormsDictList.append(stormDict)
                 elif stormStatus == "Historical":
-                    historicStorms.append(stormLabel)
+                    historicStormsDictList.append(stormDict)
                 elif stormStatus == "Exercise":
-                    exerciseStorms.append(stormLabel)
+                    exerciseStormsDictList.append(stormDict)
                 elif stormStatus == "Active":
-                    activeStorms.append(stormLabel)
-        activeStorms.sort()
-        historicStorms.sort()
-        exerciseStorms.sort()
-        simulatedStorms.sort()
+                    activeStormsDictList.append(stormDict)
+                    
+        '''Sort the lists alphabetically by stormid:essentially by number i.e. ['al012020', 'al022020']'''
+        def stormDictSortFunc(e):
+            '''use to sort a list of dictionaries by a dictionaries key's value'''
+            return e['StormId']
+        activeStormsDictList.sort(key=stormDictSortFunc)
+        historicStormsDictList.sort(key=stormDictSortFunc)
+        exerciseStormsDictList.sort(key=stormDictSortFunc)
+        simulatedStormsDictList.sort(key=stormDictSortFunc)
+
+        '''Create the stormlabels to be shown in the gui'''
+        for storm in activeStormsDictList:
+            stormName = str(storm['Name'])
+            stormStatus = str(storm['Status'])
+            stormId = str(storm['StormId'])
+            stormLabel = stormName + " (" + stormStatus + ") " + " [" + stormId + "]"
+            activeStormsLabelsList.append(stormLabel)
+        for storm in historicStormsDictList:
+            stormName = str(storm['Name'])
+            stormStatus = str(storm['Status'])
+            stormId = str(storm['StormId'])
+            stormLabel = stormName + " (" + stormStatus + ") " + " [" + stormId + "]"
+            historicStormsLabelsList.append(stormLabel)
+        for storm in exerciseStormsDictList:
+            stormName = str(storm['Name'])
+            stormStatus = str(storm['Status'])
+            stormId = str(storm['StormId'])
+            stormLabel = stormName + " (" + stormStatus + ") " + " [" + stormId + "]"
+            exerciseStormsLabelsList.append(stormLabel)
+        for storm in simulatedStormsDictList:
+            stormName = str(storm['Name'])
+            stormStatus = str(storm['Status'])
+            stormId = str(storm['StormId'])
+            stormLabel = stormName + " (" + stormStatus + ") " + " [" + stormId + "]"
+            simulatedStormsLabelsList.append(stormLabel)
+        
         '''Determine which type of storms are added to the main list'''
         if 'Active' in stormTypes:
-            for i in activeStorms:
+            for i in activeStormsLabelsList:
                 stormNameStatusIDList.append(i)
         if 'Historical' in stormTypes:
-            for i in historicStorms:
+            for i in historicStormsLabelsList:
                 stormNameStatusIDList.append(i)
         if 'Exercise' in stormTypes:
-            for i in exerciseStorms:
+            for i in exerciseStormsLabelsList:
                 stormNameStatusIDList.append(i)
         if 'Simulated' in stormTypes:
-            for i in simulatedStorms:
+            for i in simulatedStormsLabelsList:
                 stormNameStatusIDList.append(i)
         if len(stormNameStatusIDList) > 0:
             return tuple(stormNameStatusIDList)


### PR DESCRIPTION
Sorting alphabetically by stormid, which essentially orders by storm number; as the list is already split by year and basin.
I.e.: al012020, al022020